### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 IPread
 ======
 [![Build Status](https://travis-ci.org/skuschel/IPread.svg?branch=master)](https://travis-ci.org/skuschel/IPread)
-[![version](https://pypip.in/version/ipread/badge.svg)](https://pypi.python.org/pypi/ipread/)
+[![version](https://img.shields.io/pypi/v/ipread.svg)](https://pypi.python.org/pypi/ipread/)
 [![Documentation Status](https://readthedocs.org/projects/ipread/badge/?version=latest)](http://ipread.readthedocs.org)
 
 Python Module for reading Image Plates and combining several readouts to a single Image converted to PSL scale.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20ipread))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `ipread`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.